### PR TITLE
[fix] 環境構築時におけるGemfile.lockの変更追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
     net-smtp (0.3.4)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.6-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     parallel (1.25.1)
@@ -213,6 +215,7 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
環境構築においてwindowのamd64とmacのarm64でnokogiriとplatformが追加されたため、Gemfile.lockの追加をプッシュしました。