### PR TITLE
sessionsコントローラー及びserializersの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,9 @@ gem "rack-cors"
 # 環境変数を管理するためのgem
 gem 'dotenv-rails'
 
+# 認証機能を実装するためのgem
+gem 'omniauth'
+gem 'omniauth-rails_csrf_protection'
+gem 'omniauth-github', '~> 2.0.0'
+
 gem "dockerfile-rails", ">= 1.6", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,15 +97,24 @@ GEM
     drb (2.1.1)
       ruby2_keywords
     erubi (1.13.0)
+    faraday (2.10.0)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-net_http (3.1.0)
+      net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
     irb (1.6.2)
       reline (>= 0.3.0)
     json (2.7.2)
+    jwt (2.8.2)
+      base64
     language_server-protocol (3.17.0.3)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -118,7 +127,11 @@ GEM
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     mutex_m (0.1.2)
+    net-http (0.4.1)
+      uri
     net-imap (0.3.4.1)
       date
       net-protocol
@@ -133,6 +146,26 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-github (2.0.1)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -144,6 +177,9 @@ GEM
     rack (3.1.4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
+    rack-protection (4.0.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -202,12 +238,17 @@ GEM
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
+    version_gem (1.1.4)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -223,6 +264,9 @@ DEPENDENCIES
   debug
   dockerfile-rails (>= 1.6)
   dotenv-rails
+  omniauth
+  omniauth-github (~> 2.0.0)
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)
   rack-cors

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::SessionsController < ApplicationController
+  def create
+    user_info = request.env['omniauth.auth']
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,7 @@ module App
       g.helper false
       g.test_framework nil
     end
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, key: 'rqb_session'
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,4 +4,3 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   OmniAuth.config.silence_get_warning = true
   OmniAuth.config.path_prefix = '/api/v1/auth'
 end
-

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
+  OmniAuth.config.allowed_request_methods = [:post, :get]
+  OmniAuth.config.silence_get_warning = true
+  OmniAuth.config.path_prefix = '/api/v1/auth'
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'api/v1/bases#index'
   namespace :api do
     namespace :v1 do
+      get 'auth/:provider/callback', to: 'sessions#create'
     end
   end
 end


### PR DESCRIPTION
## ブランチ名
feature/user-authentication

## 概要
セッションコントローラーを作成し、ログイン機能を作成してください。
また、コントローラー作成に伴ったルーティングも行ってください
セッションコントローラーにてアクセスがあった際にはその情報を元に、githubへの遷移またはデータの送信、エラーの送信を行ってください。

## 目的 
セッションコントローラーにて認証を行うため

## 確認ポイント

- [x] セッションコントローラーの作成
- [x]  get '/auth/:provider/callback', to: 'sessions#create'とルーティング
- [x] フロント側にデータの送信

## 補足

githubとomniauthを連携する設定を作成しました。
また、これに伴ってgemの追加とsessions_controllerを作成しています。