### PR TITLE
ユーザー認証機能のトークン化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,4 +26,7 @@ gem 'omniauth'
 gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-github', '~> 2.0.0'
 
+# tokenを生成するためのgem
+gem 'jwt'
+
 gem "dockerfile-rails", ">= 1.6", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ DEPENDENCIES
   debug
   dockerfile-rails (>= 1.6)
   dotenv-rails
+  jwt
   omniauth
   omniauth-github (~> 2.0.0)
   omniauth-rails_csrf_protection

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@
 
 ```
 FRONT_URL=http://localhost:8000
+GITHUB_KEY=　「githubのClient ID　例(Ov23****************)」
+GITHUB_SECRET=　「githubのClient secrets　例(**********f118)」
+JWT_SECRET_KEY=　「生成したシークレットキー」
+
 ```
 
 ## 認証機能の追加方法
-### 以下の項目を.envファイルに追加する必要があります。（一つ一つ解説）
-
-- GITHUB_KEY=　「githubのClient ID　例(Ov23****************)」
-- GITHUB_SECRET=　「githubのClient secrets　例(**********f118)」
-- JWT_SECRET_KEY=　「生成したシークレットキー」
 
 ### GITHUB_KEYとGITHUB_SECRETについて
 GITHUB_KEYとGITHUB_SECRETはrbqのsettingの中から確認できます。

--- a/README.md
+++ b/README.md
@@ -13,3 +13,28 @@
 ```
 FRONT_URL=http://localhost:8000
 ```
+
+## 認証機能の追加方法
+### 以下の項目を.envファイルに追加する必要があります。（一つ一つ解説）
+
+- GITHUB_KEY=　「githubのClient ID　例(Ov23****************)」
+- GITHUB_SECRET=　「githubのClient secrets　例(**********f118)」
+- JWT_SECRET_KEY=　「生成したシークレットキー」
+
+### GITHUB_KEYとGITHUB_SECRETについて
+GITHUB_KEYとGITHUB_SECRETはrbqのsettingの中から確認できます。
+
+- GITHUB＿KEYは共有の(Ov23****************)
+- GITHUB_SECRETは「Generate a new client secret」にて作成
+
+上記二つは最後のproject-rqbのリンクで画面遷移を行うことで確認ができるので設定を行ってください
+※今回は安全性の確保のためproject-rqbへの画面遷移は行っていません
+
+[![Image from Gyazo](https://i.gyazo.com/ee2543c7635d94b0e473dfc122e05194.gif)](https://gyazo.com/ee2543c7635d94b0e473dfc122e05194)
+
+### JWT_SECRET_KEYについて
+JWT_SECRET_KEYはシークレットキーを生成して設定する必要があるので以下のコマンドをターミナル上で行い、キーの作成を行ってください
+
+```
+node -e "console.log(require('crypto').randomBytes(256).toString('base64'));"
+```

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,5 +1,21 @@
 class Api::V1::SessionsController < ApplicationController
+  skip_before_action :authenticate, only: [:create]
+
   def create
     user_info = request.env['omniauth.auth']
+    raise 'GitHub情報の取得に失敗しました' unless user_info
+
+    uid_info = user_info['uid']
+    provider_info = user_info['provider']
+    github_uid_info = user_info['info']['nickname']
+    token_info = encode_access_token(uid_info)
+
+    user_auth = User.find_by(uid: uid_info)
+    User.create(uid: uid_info, provider: provider_info, github_uid: github_uid_info) unless user_auth
+
+    redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
+  rescue StandardError => e
+    Rails.logger.error("認証エラー: #{e.message}")
+    redirect_to "#{ENV['FRONT_URL']}?error=authentication_failed"
   end
 end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -5,15 +5,15 @@ class Api::V1::SessionsController < ApplicationController
     user_info = request.env['omniauth.auth']
     raise 'GitHub情報の取得に失敗しました' unless user_info
 
-    uid_info = user_info['uid']
-    provider_info = user_info['provider']
-    github_uid_info = user_info['info']['nickname']
-    token_info = encode_access_token(uid_info)
+    user_uid = user_info['uid']
+    user_provider = user_info['provider']
+    user_github_uid = user_info['info']['nickname']
+    encoded_token = encode_access_token(user_uid)
 
-    user_auth = User.find_by(uid: uid_info)
-    User.create(uid: uid_info, provider: provider_info, github_uid: github_uid_info) unless user_auth
+    existing_user = User.find_by(uid: user_uid)
+    User.create(uid: user_uid, provider: user_provider, github_uid: user_github_uid) unless existing_user
 
-    redirect_to "#{ENV['FRONT_URL']}/auth?token=#{token_info}", allow_other_host: true
+    redirect_to "#{ENV['FRONT_URL']}/auth?token=#{encoded_token}", allow_other_host: true
   rescue StandardError => e
     Rails.logger.error("認証エラー: #{e.message}")
     redirect_to "#{ENV['FRONT_URL']}?error=authentication_failed"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+  include JwtAuthenticator
+  before_action :authenticate
 end

--- a/app/models/concerns/jwt_authenticator.rb
+++ b/app/models/concerns/jwt_authenticator.rb
@@ -1,0 +1,23 @@
+module JwtAuthenticator
+  class UnableAuthorizationError < StandardError; end
+
+  def authenticate
+    authorization_header = request.headers['Authorization']
+    encoded_token = authorization_header.split('Bearer ').last
+    decoded_token_payload = decode(encoded_token)
+    @current_user = UserAuthentication.find_by(uid: decoded_token_payload["uid"]).user
+  end
+
+  def encode_access_token(uid_info)
+    exp_info = Time.now.to_i + 12 * 3600
+    payload = { uid: uid_info, exp: exp_info }
+    JWT.encode(payload, ENV['JWT_SECRET_KEY'], 'HS256')
+  end
+
+  def decode(encoded_token)
+    decoded_token = JWT.decode(encoded_token, ENV['JWT_SECRET_KEY'], true, algorithm: 'HS256')
+    decoded_token.first
+  rescue JWT::DecodeError => e
+    raise UnableAuthorizationError.new("トークンの復号化に失敗しました: #{e.message}")
+  end
+end

--- a/app/models/concerns/jwt_authenticator.rb
+++ b/app/models/concerns/jwt_authenticator.rb
@@ -5,11 +5,11 @@ module JwtAuthenticator
     authorization_header = request.headers['Authorization']
     encoded_token = authorization_header.split('Bearer ').last
     decoded_token_payload = decode(encoded_token)
-    @current_user = UserAuthentication.find_by(uid: decoded_token_payload["uid"]).user
+    @current_user = User.find_by(uid: decoded_token_payload['uid'])
   end
 
   def encode_access_token(uid_info)
-    exp_info = Time.now.to_i + 12 * 3600
+    exp_info = Time.now.to_i + 12 * 60 * 60
     payload = { uid: uid_info, exp: exp_info }
     JWT.encode(payload, ENV['JWT_SECRET_KEY'], 'HS256')
   end


### PR DESCRIPTION
## ブランチ名
feature/jwt

## 概要
omniauthで取得したデータをjwtを使用してトークン化してください。

## 目的 
omniauthで取得したデータをフロント側で保管するため、トークン化を行うことでデータの安全性を確保する

## 確認ポイント

- [x] omniauthのデータをトークン化
- [x] トークンの復号
- [x] current_userの定義
- [x] モジュールで作成
- [x] applications_controllerでの読み込み

## 補足
他必要なものあればプルリク時に記載してください。
以下のような動作になります。
※複合テストボタンについては、個人的に使用できるか確認のために作成しましたのでgithub上には上ていません。

[![Image from Gyazo](https://i.gyazo.com/d6772420efb4a477c04b401ea98a673c.gif)](https://gyazo.com/d6772420efb4a477c04b401ea98a673c)

## 設定方法
### 以下の項目を.envファイルに追加する必要があります。（一つ一つ解説）

- GITHUB_KEY=　「githubのClient ID　例(Ov23****************)」
- GITHUB_SECRET=　「githubのClient secrets　例(**********f118)」
- JWT_SECRET_KEY=　「生成したシークレットキー」

### GITHUB_KEYとGITHUB_SECRETについて
GITHUB_KEYとGITHUB_SECRETはrbqのsettingの中から確認できます。

- GITHUB＿KEYは共有の(Ov23****************)
- GITHUB_SECRETは「Generate a new client secret」にて作成

上記二つは最後のproject-rqbのリンクで画面遷移を行うことで確認ができるので設定を行ってください
※今回は安全性の確保のためproject-rqbへの画面遷移は行っていません

[![Image from Gyazo](https://i.gyazo.com/ee2543c7635d94b0e473dfc122e05194.gif)](https://gyazo.com/ee2543c7635d94b0e473dfc122e05194)

### JWT_SECRET_KEYについて
JWT_SECRET_KEYはシークレットキーを生成して設定する必要があるので以下のコマンドをターミナル上で行い、キーの作成を行ってください

```
node -e "console.log(require('crypto').randomBytes(256).toString('base64'));"
```

### 適宜不明点、うまくいかないなどあればコメントいただければ幸いです