### PR TITLE
questionモデルの作成

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,17 @@
+class Question < ApplicationRecord
+  before_create :set_uuid
+  belongs_to :user
+
+  validates :uuid, presence: true, uniqueness: true
+  validates :title, presence: true, length: { maximum: 150 }
+  validates :body, presence: true
+  validates :status, presence: true
+
+  enum status: { open: 0, close: 1 }
+
+  private
+
+  def set_uuid
+    self.uuid = SecureRandom.uuid
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -9,6 +9,10 @@ class Question < ApplicationRecord
 
   enum status: { open: 0, close: 1 }
 
+  def short_uuid
+    Base64.urlsafe_encode64([uuid.delete('-')].pack("H*")).tr('=', '')
+  end
+
   private
 
   def set_uuid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :questions
+  
   validates :uid, presence: true, uniqueness: true
   validates :provider, presence: true
   validates :github_uid, presence: true, uniqueness: true

--- a/db/migrate/20240711084801_create_questions.rb
+++ b/db/migrate/20240711084801_create_questions.rb
@@ -1,0 +1,15 @@
+class CreateQuestions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :questions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :uuid, null: false
+      t.string :title, null: false, limit: 150
+      t.text :body, null: false
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :questions, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_05_143355) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_11_084801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "questions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "uuid", null: false
+    t.string "title", limit: 150, null: false
+    t.text "body", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_questions_on_user_id"
+    t.index ["uuid"], name: "index_questions_on_uuid", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.integer "uid", null: false
@@ -26,4 +38,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_143355) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "questions", "users"
 end


### PR DESCRIPTION
## ブランチ名
feature/question-model
<br>

## 概要
questionモデル及びそれに紐づくquestionテーブルの作成。
<br>

## 実装項目
### 必要カラム

- user_id：references型
- uuid：必須
- title：必須、150文字上限
- body：必須
- status：必須、初期値(0:open)
<br>

## 目的
questionモデルを作成し、今後ユーザーが投稿したデータを使用するため。
<br>

## 確認ポイント

- [x] questionモデルの作成
- [x] userモデルへの関連付け・従属
- [x] questionsテーブルのカラム
  - [x] user_id
  - [x] uuid
  - [x] title
  - [x] body
  - [x] status
<br>

## 補足
Userモデルとの関連付けのために、`models/user.rb`ファイル内にアソシエーション定義を記述しました。
また、statusカラムの記事ステータス管理については、`model/question.rb`ファイル内にEnumを定義しています。
 
作成には以下のER図を参考に行っています。
![Image](https://github.com/Project-RQB/Project-RQB-back/assets/126387954/0c90fe8a-c86b-4d51-a79f-206533ab32fe)