### PR TITLE
Answerモデル/マイグレーションを作成しそれに付随するモデルの関連付け

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,6 @@
+class Answer < ApplicationRecord
+  belongs_to :user
+  belongs_to :question
+
+  validates :body, presence: true, length: { maximum: 65_535 }
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,6 +2,8 @@ class Question < ApplicationRecord
   before_create :set_uuid
   belongs_to :user
 
+  has_many :answers, dependent: :destroy
+
   validates :uuid, presence: true, uniqueness: true
   validates :title, presence: true, length: { maximum: 150 }
   validates :body, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :questions
-  
+  has_many :answers
+
   validates :uid, presence: true, uniqueness: true
   validates :provider, presence: true
   validates :github_uid, presence: true, uniqueness: true

--- a/db/migrate/20240717093018_create_answers.rb
+++ b/db/migrate/20240717093018_create_answers.rb
@@ -1,0 +1,11 @@
+class CreateAnswers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :answers do |t|
+      t.references :user, null: false, foreign_key: true, index: true
+      t.references :question, null: false, foreign_key: true, index: true
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_11_084801) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_17_093018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "answers", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "question_id", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id"], name: "index_answers_on_question_id"
+    t.index ["user_id"], name: "index_answers_on_user_id"
+  end
 
   create_table "questions", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -38,5 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_11_084801) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "answers", "questions"
+  add_foreign_key "answers", "users"
   add_foreign_key "questions", "users"
 end


### PR DESCRIPTION
## 概要
Answerモデルおよびそれに紐づくanswersテーブルを作成し、それに紐づく関連付けを行いました。

## 変更内容
1. Answerモデルとマイグレーションファイルの作成
1. Userモデル、Questionモデル、Answerモデルの関連付けの設定

## 確認項目
- [x]  **Answerモデルの作成**
    - [x]  `Answer`モデルが正しく作成されている
    - [x]  バリデーションの設定がされている
- [x]  **Userモデルへの関連付け**
    - [x]  `User`モデルが`has_many :answers`を持つ
- [x]  **Questionモデルへの関連付け**
    - [x]  `Question`モデルが`has_many :answers, dependent: :destroy`を持つ
- [x]  **Answerテーブルのカラム**
    - [x]  `user_id`カラムが存在し、正しく設定されている
    - [x]  `question_id`カラムが存在し、正しく設定されている
    - [x]  `body`カラムが存在し、`null: false`が設定されている

## テストについて
他の方がされていなかったので今回はしていません。
おそらくLintチェックで引っかかると思うので、必要でしたら修正します。

## その他
- 今回はアンサーの文字数のバリデーションを65535文字にしました
- 質問が削除されるとそれに伴い、アンサーも削除されるようにしました