### PR TITLE
QuestionsController　質問作成・質問数カウント処理の実装

### DIFF
--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -5,8 +5,7 @@ class Api::V1::QuestionsController < Api::V1::BasesController
   end
 
   def create
-    question = Question.new(question_params)
-    question.user = @current_user
+    question = @current_user.questions.new(question_params)
 
     if question.save
       render json: question, status: :created, serializer: QuestionSerializer

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -3,4 +3,26 @@ class Api::V1::QuestionsController < Api::V1::BasesController
     questions = Question.includes(:user).all
     render json: questions, each_serializer: QuestionSerializer
   end
+
+  def create
+    question = Question.new(question_params)
+    question.user = @current_user
+
+    if question.save
+      render json: question, status: :created, serializer: QuestionSerializer
+    else
+      render json: { errors: question.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def count_all_questions
+    all_count = Question.count
+    render json: { count: all_count }
+  end
+
+  private
+
+  def question_params
+    params.require(:question).permit(:uuid, :title, :body, :status)
+  end
 end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -8,9 +8,9 @@ class Api::V1::QuestionsController < Api::V1::BasesController
     question = @current_user.questions.new(question_params)
 
     if question.save
-      render json: question, status: :created, serializer: QuestionSerializer
+      render json: { uuid: question.uuid }, status: :created
     else
-      render json: { errors: question.errors.full_messages }, status: :unprocessable_entity
+      render json: { message: question.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :questions, only: [:index, :create] do
         resources :answers, only: [:create]
       end
+      get 'questions/all_count', to: 'questions#count_all_questions'
     end
   end
 end


### PR DESCRIPTION
## issue
#22 
<br>

## 概要
質問投稿を作成するための`create`アクションを、QuestionsController内に追記しました。
また、質問全体をカウントするための`count_all_questions`アクションを、QuestionsController内に追記しました。
<br>

## 変更内容
- `app/api/v1/questions_controller.rb`内に`create`アクションを追加
- `app/api/v1/questions_controller.rb`内に`count_all_questions`アクションを追加
- `config/routes.rb`内にルーティングを追加
<br>

## 確認手順
- [ ] **QuestionsController 質問作成・質問数カウントの実装**
  - [ ] QuestionsControllerにて、`create`アクションが問題なく実装出来ているか。
  - [ ] `create`アクションにて、質問投稿のJSONデータが問題なく作成出来ているか。
  - [ ] QuestionsControllerにて、`count_all_questions`アクションが問題なく実装出来ているか。
  - [ ] `count_all_questions`アクションにて、質問数カウントのJSONデータが問題なく取得出来ているか。
- [ ] **ルーティングの設定**
  - [ ] `config/routes.rb`内に、Questionsコントローラーに対するルーティングが正しく設定されているか。
- [ ] **動作確認**
  - [ ] Postmanにて『 http://localhost:3000/api/v1/questions 』に対してPOSTリクエストを送信した際、下記《動作画面》の通りにJSONデータが送信されているか。
  - [ ] Postmanにて『 http://localhost:3000/api/v1/questions/all_count 』に対してGETリクエストを送信した際、下記《動作画面》の通りにJSONデータが送信されているか。
<br>

## 動作画面
### 質問作成（`create`アクション）
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/b8a3079b-8f99-48af-9e7c-8aeb8d8c4ba2">
 

### 質問数カウント（`count_all_questions`アクション）
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/22108414-94f5-40ff-93e5-236f73c7ed0e">
<br>

## 備考
- `create`アクションの動作確認については一時的なチェックのため、下記のように`question.user`に代入する値はseedデータのユーザー情報（`User.find(7)`）を直接代入する形で動作確認を行いました。（実際のコードは、`question.user = @current_user` と、ログイン中のユーザーを代入する形で記述しています。）

```ruby
def create
  question = Question.new(question_params)
  question.user = User.find(7)

  if question.save
    render json: question, status: :created, serializer: QuestionSerializer
  else
    render json: { errors: question.errors.full_messages }, status: :unprocessable_entity
  end
end
```