### PR TITLE
質問詳細ページの不足ロジック追加

### DIFF
--- a/app/controllers/api/v1/answers_controller.rb
+++ b/app/controllers/api/v1/answers_controller.rb
@@ -2,6 +2,8 @@
 
 # This controller handles the creation of answers associated with a question
 class Api::V1::AnswersController < Api::V1::BasesController
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
   def index
     question = Question.find_by!(uuid: params[:question_id])
 
@@ -25,5 +27,9 @@ class Api::V1::AnswersController < Api::V1::BasesController
 
   def answer_params
     params.require(:answer).permit(:body)
+  end
+
+  def record_not_found
+    render json: { error: '質問が見つかりません' }, status: :not_found
   end
 end

--- a/app/controllers/api/v1/answers_controller.rb
+++ b/app/controllers/api/v1/answers_controller.rb
@@ -3,9 +3,14 @@
 # This controller handles the creation of answers associated with a question
 class Api::V1::AnswersController < Api::V1::BasesController
   def index
-    question = Question.find_by!(uuid: params[:question_id])
-    answers = question.answers
+    question = Question.find_by(uuid: params[:question_id])
 
+    if question.nil?
+      render json: { error: 'Question not found' }, status: :not_found
+      return
+    end
+
+    answers = question.answers
     render json: answers, each_serializer: AnswerSerializer
   end
 

--- a/app/controllers/api/v1/answers_controller.rb
+++ b/app/controllers/api/v1/answers_controller.rb
@@ -2,15 +2,22 @@
 
 # This controller handles the creation of answers associated with a question
 class Api::V1::AnswersController < Api::V1::BasesController
+  def index
+    question = Question.find_by!(uuid: params[:question_id])
+    answers = question.answers
+
+    render json: answers, each_serializer: AnswerSerializer
+  end
+
   def create
-    question = Question.find(params[:question_id])
-    answer = question.answers.build(answer_params)
+    question = Question.find_by!(uuid: params[:question_id])
+    answer = question.answers.new(answer_params)
     answer.user = @current_user
 
-    if @answer.save
+    if answer.save
       render json: answer, status: :created, serializer: AnswerSerializer
     else
-      render json: answer.errors, status: :unprocessable_entity, serializer: AnswerSerializer
+      render json: { errors: answer.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -30,6 +30,12 @@ module Api
 
       def show
         question = Question.find_by(uuid: params[:id])
+
+        if question.nil?
+          render json: { error: 'Question not found' }, status: :not_found
+          return
+        end
+
         render json: question, serializer: QuestionSerializer
       end
 

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -5,6 +5,8 @@ include Pagy::Backend
 module Api
   module V1
     class QuestionsController < Api::V1::BasesController
+      rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
       def index
         current_page = params[:page] || 1
         order_by = params[:order] || 'new'
@@ -30,7 +32,6 @@ module Api
 
       def show
         question = Question.find_by!(uuid: params[:id])
-
         render json: question, serializer: QuestionSerializer
       end
 
@@ -52,6 +53,10 @@ module Api
 
       def question_params
         params.require(:question).permit(:uuid, :title, :body, :status)
+      end
+
+      def record_not_found
+        render json: { error: '質問が見つかりません' }, status: :not_found
       end
     end
   end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -21,9 +21,23 @@ module Api
         end
       end
 
+      def show
+        question = Question.find_by(uuid: params[:id])
+        render json: question, serializer: QuestionSerializer
+      end
+
       def count_all_questions
         all_count = Question.count
         render json: { count: all_count }
+      end
+
+      def close
+        question = Question.find_by!(uuid: params[:id])
+        if question.update(status: 'close')
+          render json: { status: question.status }, status: :ok
+        else
+          render json: { errors: question.errors.full_messages }, status: :unprocessable_entity
+        end
       end
 
       private

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -2,7 +2,11 @@
 
 # Serializer for the Answer model
 class AnswerSerializer < ActiveModel::Serializer
-  attributes :id, :body, :created_at, :updated_at
+  attributes :id, :body, :created_at
   belongs_to :question
   belongs_to :user
+
+  def created_at
+    object.created_at.strftime('%Y/%m/%d %H:%M')
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,11 @@ Rails.application.routes.draw do
       get 'auth/:provider/callback', to: 'sessions#create'
       get 'auth/me', to: 'sessions#me'
 
-      resources :questions, only: [:index, :create] do
-        resources :answers, only: [:create]
+      resources :questions, only: %i[index create show] do
+        resources :answers, only: %i[create index]
+        member do
+          patch 'close', to: 'questions#close'
+        end
       end
       get 'questions/all_count', to: 'questions#count_all_questions'
     end


### PR DESCRIPTION
## 概要

質問詳細ページにおいての足りないロジックの追加を行いました。

## 変更内容

- questionsコントローラ
  - 質問詳細を表示するための`show`アクション追加
  - 質問の状態を未解決から解決済にするための`close`アクションを追加
- answersコントローラ
  - `index`アクション追加
- AnswerSerializerに作成時間を記録するcreated_atを追加
- 追加したアクションに対応するルートの設定

## 確認ポイント

- questionsコントローラ
  - [x] 【GET】質問詳細の取得ができているか
  - [x] 【PAUCH】質問を解決済みにできるか

- answersコントローラ
  - [x] 【GET】アンサー一覧の取得ができてるか
  - [x] 【POST】アンサーを作成できているか

## 動作確認

| GET | PATCH |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/855efb2567f33a5dc1df4f652ac7a209.png)](https://gyazo.com/855efb2567f33a5dc1df4f652ac7a209) | [![Image from Gyazo](https://i.gyazo.com/f6459418110b7d30d81b255b6a04be0f.png)](https://gyazo.com/f6459418110b7d30d81b255b6a04be0f) |

| POST | GET |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/a894327b8626b16c0a0c0bfa5a57d98d.png)](https://gyazo.com/a894327b8626b16c0a0c0bfa5a57d98d) | [![Image from Gyazo](https://i.gyazo.com/dec5cfab9d67b4b41b381360c596defa.png)](https://gyazo.com/dec5cfab9d67b4b41b381360c596defa) |