### PR TITLE
tagモデルの作成およびバリデーションの追加

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20240903001311_create_tags.rb
+++ b/db/migrate/20240903001311_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+    end
+
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_19_131816) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_03_001311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_19_131816) do
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_questions_on_user_id"
     t.index ["uuid"], name: "index_questions_on_uuid", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 概要

tagsモデルの作成およびバリデーションの追加をしました。

## 変更内容

- tagsモデルの作成
- tagsテーブルにnameカラムを追加し、null: false制約を設定
- nameカラムにunique: true制約を追加し、重複を防止
- nameに対するpresence: trueバリデーションを追加
