### PR TITLE
ChatGPTに質問のレビューをしてもらう実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,6 @@ gem 'active_model_serializers'
 
 # ページネーション
 gem 'pagy', '~> 9.0'
+
+# リクエストを送信するためのgem
+gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
+    csv (3.3.0)
     date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
@@ -112,6 +113,10 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -274,6 +279,7 @@ DEPENDENCIES
   debug
   dockerfile-rails (>= 1.6)
   dotenv-rails
+  httparty
   jwt
   omniauth
   omniauth-github (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FRONT_URL=http://localhost:8000
 GITHUB_KEY=　「githubのClient ID　例(Ov23****************)」
 GITHUB_SECRET=　「githubのClient secrets　例(**********f118)」
 JWT_SECRET_KEY=　「生成したシークレットキー」
-
+OPENAI_API_KEY=
 ```
 
 ## 認証機能の追加方法
@@ -37,3 +37,5 @@ JWT_SECRET_KEYはシークレットキーを生成して設定する必要があ
 ```
 node -e "console.log(require('crypto').randomBytes(256).toString('base64'));"
 ```
+## OpenAI APIの秘密鍵について
+秘匿情報なので別途送らせていただきます。

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -11,8 +11,8 @@ module Api
         current_page = params[:page] || 1
         order_by = params[:order] || 'new'
         order_by = order_by == 'new' ? 'desc' : 'asc'
-        _, questions = pagy(Question.includes(:user).all.order("created_at #{order_by}"), items: 10,
-                                                                                          page: current_page)
+        _, questions = pagy(Question.includes(:user, :tags).all.order("created_at #{order_by}"), items: 10,
+                                                                                                 page: current_page)
         render json: questions, each_serializer: QuestionSerializer
       end
 

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -8,18 +8,17 @@ module Api
       def index
         current_page = params[:page] || 1
         order_by = params[:order] || 'new'
-        order_by = if order_by == 'new'
-                     'desc'
-                   else
-                     'asc'
-                   end
+        order_by = order_by == 'new' ? 'desc' : 'asc'
         _, questions = pagy(Question.includes(:user).all.order("created_at #{order_by}"), items: 10,
                                                                                           page: current_page)
         render json: questions, each_serializer: QuestionSerializer
       end
 
       def create
-        question = @current_user.questions.new(question_params)
+        question_params_without_tags = question_params.except(:tags)
+        question = @current_user.questions.new(question_params_without_tags)
+
+        # TODO: tagsを保存する処理を追加する
 
         if question.save
           render json: { uuid: question.uuid }, status: :created
@@ -33,10 +32,22 @@ module Api
         render json: { count: all_count }
       end
 
+      def ai_review
+        title = question_params[:title]
+        body = question_params[:body]
+        tags = question_params[:tags]
+        begin
+          review = Chatgpt.call(title, tags, body)
+          render json: { review: }, status: :ok
+        rescue Net::ReadTimeout
+          render json: { review: 'AIのレビューがタイムアウトしました。' }, status: :gateway_timeout
+        end
+      end
+
       private
 
       def question_params
-        params.require(:question).permit(:uuid, :title, :body, :status)
+        params.require(:question).permit(:uuid, :title, :body, :status, tags: [])
       end
     end
   end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -19,8 +19,7 @@ module Api
       def create
         question_params_without_tags = question_params.except(:tags)
         question = @current_user.questions.new(question_params_without_tags)
-
-        # TODO: tagsを保存する処理を追加する
+        question.add_tags(question_params[:tags])
 
         if question.save
           render json: { uuid: question.uuid }, status: :created

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-include Pagy::Backend
-
 module Api
   module V1
+    # 質問に関するAPIを管理するクラス
     class QuestionsController < Api::V1::BasesController
+      include Pagy::Backend
       def index
         current_page = params[:page] || 1
         order_by = params[:order] || 'new'

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -14,4 +14,13 @@ class Question < ApplicationRecord
   validates :status, presence: true
 
   enum status: { open: 0, close: 1 }
+
+  def add_tags(tags)
+    return if tags.blank?
+
+    tags.each do |tag|
+      tag = Tag.find_or_create_by(name: tag)
+      self.tags << tag
+    end
+  end
 end

--- a/app/services/chatgpt.rb
+++ b/app/services/chatgpt.rb
@@ -1,0 +1,79 @@
+class Chatgpt
+  include HTTParty
+
+  attr_reader :api_url, :options, :model, :message
+
+  def initialize(title, tags, question, model)
+    api_key = ENV['OPENAI_API_KEY']
+    @options = {
+      headers: {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{api_key}"
+      }
+    }
+    @api_url = 'https://api.openai.com/v1/chat/completions'
+    @model = model
+    @title = title
+    @tags = tags.join(', ')
+    @question = question
+  end
+
+  def call
+    body = {
+      model:,
+      messages: [{ role: 'user', content: prompt }]
+    }
+    response = HTTParty.post(@api_url, body: body.to_json, **options, timeout: 100)
+    raise response['error']['message'] unless response.code == 200
+
+    response['choices'][0]['message']['content']
+  end
+
+  class << self
+    def call(title, tags, question, model = 'gpt-4o-mini')
+      new(title, tags, question, model).call
+    end
+  end
+
+  private
+
+  def prompt
+    <<~EOS
+      あなたはテックリードのWebエンジニアです。あなたのチームに実務未経験の新人エンジニアが配属されました。あるプロジェクトにおいて新人エンジニアから質問が来ました。
+      以下の要件と形式に沿って、新人エンジニアからの質問の仕方をレビューしてください。
+
+      ## 要件
+      - 質問内容を10点満点で評価してください。
+      - 質問内容に対する回答は不要です。
+      - 質問内容が明確であるかどうかを評価してください。
+      - 質問に対して必要な情報が適切に含まれているかどうかを評価してください。
+      - 質問はマークダウンで記述されています。
+      - 質問内容が適切にマークダウンで記述されているかどうかを評価してください。
+      - タイトル、タグ、質問内容が適切に記述されているかどうかを評価してください。
+      - タイトルからどんな質問なのか想像できるかどうかを評価してください。
+      - タグが適切に設定されているかどうかを評価してください。
+      - 改善が必要な場合のみ、タイトル、タグ、質問内容を修正するように指示してください。
+
+      ## 形式
+      - Markdonw形式でレビューしてください
+      - 一番初めは、h3タグで「質問の点数」として点数を表示してください。
+      - 2番目は、h3タグで「良い点」を表示してください。
+      - 3番目は、良い点をリスト形式で表示してください。
+      - 4番目は、h3タグで「改善点」を表示してください。
+      - 5番目は、改善点をリスト形式で表示してください。
+      - 6番目は、h3タグで「改善案」を表示してください。
+      - 7番目は、改善案をリスト形式で表示してください。
+      - 全体はコードブロックで囲わないでください。
+
+      ## 質問タイトル
+      #{@title}
+
+      ## 質問に紐づいているタグ
+      #{@tags}
+
+      ## 質問内容
+      ここ以降はすべて質問内容です。
+      #{@message}
+    EOS
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,11 @@ Rails.application.routes.draw do
       get 'auth/:provider/callback', to: 'sessions#create'
       get 'auth/me', to: 'sessions#me'
 
-      resources :questions, only: [:index, :create] do
+      resources :questions, only: %i[index create] do
         resources :answers, only: [:create]
       end
       get 'questions/all_count', to: 'questions#count_all_questions'
+      post 'questions/ai_review', to: 'questions#ai_review'
     end
   end
 end


### PR DESCRIPTION
# 概要
OpenAI APIを用いてChatGPTにフロントからPOSTされたデータとともにレビューをしてもらう実装を行いました。

# 実装内容
- ChatGPT-4o miniを使い質問内容のレビュー
   - タイトル、タグ、本文をレビュー対象に設定
   - 10点満点中の点数を出力
   - 良い点、改善点、改善案の提案を出力

## プロンプト
ヒアドキュメントで記されている下記の部分です。
```ruby
  def prompt
    <<~REVIEW_PROMPT
      あなたはテックリードのWebエンジニアです。あなたのチームに実務未経験の新人エンジニアが配属されました。あるプロジェクトにおいて新人エンジニアから質問が来ました。
      以下の要件と形式に沿って、新人エンジニアからの質問の仕方をレビューしてください。
      ## 要件
      - 質問内容を10点満点で評価してください。
      - 質問内容に対する回答は不要です。
      - 質問内容が明確であるかどうかを評価してください。
      - 質問に対して必要な情報が適切に含まれているかどうかを評価してください。
      - 質問はマークダウンで記述されています。
      - 質問内容が適切にマークダウンで記述されているかどうかを評価してください。
      - タイトル、タグ、質問内容が適切に記述されているかどうかを評価してください。
      - タイトルからどんな質問なのか想像できるかどうかを評価してください。
      - タグが適切に設定されているかどうかを評価してください。
      - 改善が必要な場合のみ、タイトル、タグ、質問内容を修正するように指示してください。
      ## 形式
      - Markdonw形式でレビューしてください
      - 一番初めは、h3タグで「質問の点数」として点数を表示してください。
      - 2番目は、h3タグで「良い点」を表示してください。
      - 3番目は、良い点をリスト形式で表示してください。
      - 4番目は、h3タグで「改善点」を表示してください。
      - 5番目は、改善点をリスト形式で表示してください。
      - 6番目は、h3タグで「改善案」を表示してください。
      - 7番目は、改善案をリスト形式で表示してください。
      - 全体はコードブロックで囲わないでください。
      ## 質問タイトル
      #{@title}
      ## 質問に紐づいているタグ
      #{@tags}
      ## 質問内容
      ここ以降はすべて質問内容です。
      #{@message}
    REVIEW_PROMPT
  end
```
形式の
> 全体はコードブロックで囲わないでください。

については、コードブロックで囲って返却されることがあったので追加しています。

## 挙動
※質問詳細ページ（回答ページ）のAPI側が未実装のため、投稿に成功するとページ遷移でエラーが出ています。
　https://github.com/project-rqb/project-rqb-back/pull/54 で解決すると想定しています。
[動作確認動画](https://i.gyazo.com/8d21fc077886b4bf0f641d6e6c222524.mp4)

# 相談
## プロンプトについて
タイトル、タグ、質問内容が「テスト投稿」でもそこそこ良い点数が出てしまうので「激辛でお願いします」としたら今度は割と良さげな質問も8点を超えなくなってしまったのでどうしたもんかと悩んでいます。
プロンプト周りなにか良い提案あればコメント頂ければと思います 🙏 

## 回数制限について
初動で回数制限を設けると投稿しづらくなる＝投稿数が少なそう？と思い改めて協議したいです。
一旦回数制限無しにしています。
