### PR TITLE
質問詳細にてtag表示の機能

### DIFF
--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -58,7 +58,7 @@ module Api
       private
 
       def question_params
-        params.require(:question).permit(:uuid, :title, :body, :status, tag_ids: [])
+        params.require(:question).permit(:uuid, :title, :body, :status)
       end
 
       def record_not_found

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -55,17 +55,6 @@ module Api
         render json: tags, each_serializer: TagSerializer
       end
 
-      def tag
-        question = Question.find_by!(uuid: params[:id])
-        tag = question.tags.find_by(id: params[:tag_id])
-
-        if tag.nil?
-          render json: { message: 'タグが見つかりません' }, status: :ok
-        else
-          render json: tag, serializer: TagSerializer
-        end
-      end
-
       private
 
       def question_params

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -49,10 +49,27 @@ module Api
         end
       end
 
+      def tags
+        question = Question.find_by!(uuid: params[:id])
+        tags = question.tags
+        render json: tags, each_serializer: TagSerializer
+      end
+
+      def tag
+        question = Question.find_by!(uuid: params[:id])
+        tag = question.tags.find_by(id: params[:tag_id])
+
+        if tag.nil?
+          render json: { message: 'タグが見つかりません' }, status: :ok
+        else
+          render json: tag, serializer: TagSerializer
+        end
+      end
+
       private
 
       def question_params
-        params.require(:question).permit(:uuid, :title, :body, :status)
+        params.require(:question).permit(:uuid, :title, :body, :status, tag_ids: [])
       end
 
       def record_not_found

--- a/app/models/question_tag.rb
+++ b/app/models/question_tag.rb
@@ -4,5 +4,5 @@ class QuestionTag < ApplicationRecord
 
   validates :question_id, uniqueness: { scope: :tag_id }
   validates :name, length: { maximum: 30, message: 'は最大30文字までです' }
-  validates :name, format: { with: /\A[a-z0-9]+\z/, message: 'は小文字のアルファベットと数字のみ使用できます' }
+  validates :name, format: { with: /\A[a-zA-Z0-9]+\z/, message: 'はアルファベットと数字のみ使用できます' }
 end

--- a/app/models/question_tag.rb
+++ b/app/models/question_tag.rb
@@ -3,6 +3,4 @@ class QuestionTag < ApplicationRecord
   belongs_to :tag
 
   validates :question_id, uniqueness: { scope: :tag_id }
-  validates :name, length: { maximum: 30, message: 'は最大30文字までです' }
-  validates :name, format: { with: /\A[a-zA-Z0-9]+\z/, message: 'はアルファベットと数字のみ使用できます' }
 end

--- a/app/models/question_tag.rb
+++ b/app/models/question_tag.rb
@@ -3,4 +3,6 @@ class QuestionTag < ApplicationRecord
   belongs_to :tag
 
   validates :question_id, uniqueness: { scope: :tag_id }
+  validates :name, length: { maximum: 30, message: 'は最大30文字までです' }
+  validates :name, format: { with: /\A[a-z0-9]+\z/, message: 'は小文字のアルファベットと数字のみ使用できます' }
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -6,5 +6,6 @@ class Tag < ApplicationRecord
   has_many :user_learned_tags
   has_many :learned_users, through: :user_learned_tags, source: :user
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, length: { maximum: 30, message: 'は最大30文字までです' },
+                   format: { with: /\A[a-zA-Z0-9\-_\.]+\z/, message: 'はアルファベット、半角数字、-、_、. のみ使用できます。' }
 end

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -4,6 +4,8 @@ class QuestionSerializer < ActiveModel::Serializer
   attributes :uuid, :title, :body, :status, :created_at
   belongs_to :user, serializer: UserSerializer
 
+  has_many :tags
+
   def created_at
     object.created_at.strftime('%Y/%m/%d %H:%M')
   end

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,0 +1,3 @@
+class TagSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Rails.application.routes.draw do
         member do
           patch 'close', to: 'questions#close'
           get 'tags', to: 'questions#tags'
-          get 'tags/:tag_id', to: 'questions#tag'
         end
       end
       get 'questions/all_count', to: 'questions#count_all_questions'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,12 @@ Rails.application.routes.draw do
         resources :answers, only: %i[create index]
         member do
           patch 'close', to: 'questions#close'
+          get 'tags', to: 'questions#tags'
+          get 'tags/:tag_id', to: 'questions#tag'
         end
       end
       get 'questions/all_count', to: 'questions#count_all_questions'
     end
   end
 end
+


### PR DESCRIPTION
## 概要

質問詳細にてタグの情報を取得するためにquestionsコントローラにて処理を追加しました。

## 変更内容

- questionコントローラにtagメソッド追加
- 質問にtagがない場合は空配列を返す処理
- タグの文字数とフォーマットのバリデーション追加
- TagSerializerの設定

## 動作確認

| tagがある場合 | tagがない場合 |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/d9fbe5b19613284ba4a28546d28864f5.png)](https://gyazo.com/d9fbe5b19613284ba4a28546d28864f5) | [![Image from Gyazo](https://i.gyazo.com/3f7f1728047777432395b127774d9a8b.png)](https://gyazo.com/3f7f1728047777432395b127774d9a8b) |
| 例外 |
| [![Image from Gyazo](https://i.gyazo.com/9a740d3305da9823917650c9a83e5a15.png)](https://gyazo.com/9a740d3305da9823917650c9a83e5a15) |

## 補足

tagの文字数とフォーマット(数字,英語のみの)のバリデーション設定を行いました。修正必要であれば修正します。
また、マイグレーションレベルで制限をかけたほうがいい場合はそちらも修正します。

