### PR TITLE
[fix]新規登録時にユーザー名を設定

### DIFF
--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -15,8 +15,8 @@ module Api
                    else
                      'asc'
                    end
-        _, questions = pagy(Question.includes(:user).all.order("created_at #{order_by}"), items: 10,
-                                                                                          page: current_page)
+        _, questions = pagy(Question.includes(:user).references(:user).all
+                            .order("questions.created_at #{order_by}"), items: 10, page: current_page)
         render json: questions, each_serializer: QuestionSerializer
       end
 

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -11,7 +11,10 @@ class Api::V1::SessionsController < Api::V1::BasesController
     encoded_token = encode_access_token(user_uid)
 
     existing_user = User.find_by(uid: user_uid)
-    User.create(uid: user_uid, provider: user_provider, github_uid: user_github_uid) unless existing_user
+    unless existing_user
+      User.create(uid: user_uid, provider: user_provider, github_uid: user_github_uid,
+                  name: user_github_uid)
+    end
 
     redirect_to "#{ENV['FRONT_URL']}?token=#{encoded_token}", allow_other_host: true
   rescue StandardError => e

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,13 @@ Rails.application.routes.draw do
       get 'auth/:provider/callback', to: 'sessions#create'
       get 'auth/me', to: 'sessions#me'
 
+      get 'questions/all_count', to: 'questions#count_all_questions'
       resources :questions, only: %i[index create show] do
         resources :answers, only: %i[create index]
         member do
           patch 'close', to: 'questions#close'
         end
       end
-      get 'questions/all_count', to: 'questions#count_all_questions'
     end
   end
 end


### PR DESCRIPTION
# 概要
新規登録時にGitHubのニックネームをユーザー名に設定する処理を実装しました

## 補足
- ルーティングの順番が以前のままだと`questions/:id`（`questions/show`）と衝突するため、順番を変更しました。

## 挙動
質問一覧取得時にユーザー名も取得できています。
![image](https://github.com/user-attachments/assets/5e6347be-7ca8-49c3-893b-85198d14fd1f)
