### PR TITLE
【feature】ユーザープロフィール実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/public/avatars

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM base as build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config
+    apt-get install --no-install-recommends -y build-essential git libpq-dev libvips pkg-config imagemagick
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./
@@ -39,7 +39,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl libvips postgresql-client imagemagick && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM ruby:3.2.2
 ENV LANG C.UTF-8
 ENV TZ Asia/Tokyo
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev libvips
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev libvips imagemagick
 RUN mkdir /app
 WORKDIR /app
 RUN gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,15 @@ gem 'pagy', '~> 9.0'
 
 # リクエストを送信するためのgem
 gem 'httparty'
+
+# 画像アップローダー
+gem 'carrierwave', '~> 3.0'
+# base64形式の画像をアップロードするためのgem
+gem 'carrierwave-base64'
+
+# AWS S3に画像をアップロードするためのgem
+gem 'fog-aws', group: :production
+
+# 画像加工
+gem 'image_processing', '~> 1.2'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,12 +80,25 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.1.1)
     bigdecimal (3.1.3)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
+    carrierwave-base64 (2.11.0)
+      carrierwave (>= 2.2.1)
+      marcel (~> 1.0.0)
+      mime-types (~> 3.0)
     case_transform (0.2)
       activesupport
     concurrent-ruby (1.3.3)
@@ -105,11 +118,30 @@ GEM
     drb (2.1.1)
       ruby2_keywords
     erubi (1.13.0)
+    excon (0.111.0)
     faraday (2.10.0)
       faraday-net_http (>= 2.0, < 3.2)
       logger
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-gnu)
+    fog-aws (3.24.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.5.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -119,6 +151,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.6.0)
     irb (1.6.2)
       reline (>= 0.3.0)
@@ -137,9 +172,14 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0903)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.1.2)
@@ -185,6 +225,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    public_suffix (6.0.1)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
@@ -251,10 +292,14 @@ GEM
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    ssrf_filter (1.1.2)
     strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
@@ -276,11 +321,16 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   bootsnap
+  carrierwave (~> 3.0)
+  carrierwave-base64
   debug
   dockerfile-rails (>= 1.6)
   dotenv-rails
+  fog-aws
   httparty
+  image_processing (~> 1.2)
   jwt
+  mini_magick
   omniauth
   omniauth-github (~> 2.0.0)
   omniauth-rails_csrf_protection

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,30 @@
+class Api::V1::UsersController < Api::V1::BasesController
+  def show
+    user = User.find_by(uuid: params[:id])
+    if user.present?
+      render json: user, serializer: UserSerializer, status: :ok
+    else
+      render json: { error: 'ユーザーが見つかりません' }, status: :not_found
+    end
+  end
+
+  def update
+    @current_user.add_learned_tags(user_params[:learned_tags])
+    @current_user.add_learning_tags(user_params[:learning_tags])
+    user_params_without_tags = user_params.except(:learned_tags, :learning_tags)
+
+    begin
+      @current_user.update!(user_params_without_tags)
+      render json: @current_user, serializer: UserSerializer, status: :ok
+    rescue StandardError => e
+      Rails.logger.error(e.message)
+      render json: { error: e.message }, status: :bad_request
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :profile, :avatar, learned_tags: [], learning_tags: [])
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,30 +1,36 @@
-class Api::V1::UsersController < Api::V1::BasesController
-  def show
-    user = User.find_by(uuid: params[:id])
-    if user.present?
-      render json: user, serializer: UserSerializer, status: :ok
-    else
-      render json: { error: 'ユーザーが見つかりません' }, status: :not_found
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UsersController < Api::V1::BasesController
+      def show
+        user = User.find_by(uuid: params[:id])
+        if user.present?
+          render json: user, serializer: UserSerializer, status: :ok
+        else
+          render json: { error: 'ユーザーが見つかりません' }, status: :not_found
+        end
+      end
+
+      def update
+        @current_user.add_learned_tags(user_params[:learned_tags])
+        @current_user.add_learning_tags(user_params[:learning_tags])
+        user_params_without_tags = user_params.except(:learned_tags, :learning_tags)
+
+        begin
+          @current_user.update!(user_params_without_tags)
+          render json: @current_user, serializer: UserSerializer, status: :ok
+        rescue StandardError => e
+          Rails.logger.error(e.message)
+          render json: { error: e.message }, status: :bad_request
+        end
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:name, :profile, :avatar, learned_tags: [], learning_tags: [])
+      end
     end
-  end
-
-  def update
-    @current_user.add_learned_tags(user_params[:learned_tags])
-    @current_user.add_learning_tags(user_params[:learning_tags])
-    user_params_without_tags = user_params.except(:learned_tags, :learning_tags)
-
-    begin
-      @current_user.update!(user_params_without_tags)
-      render json: @current_user, serializer: UserSerializer, status: :ok
-    rescue StandardError => e
-      Rails.logger.error(e.message)
-      render json: { error: e.message }, status: :bad_request
-    end
-  end
-
-  private
-
-  def user_params
-    params.require(:user).permit(:name, :profile, :avatar, learned_tags: [], learning_tags: [])
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Tag < ApplicationRecord
   has_many :question_tags
   has_many :questions, through: :question_tags

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -7,5 +7,5 @@ class Tag < ApplicationRecord
   has_many :learned_users, through: :user_learned_tags, source: :user
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 30, message: 'は最大30文字までです' },
-                   format: { with: /\A[a-zA-Z0-9\-_\.]+\z/, message: 'はアルファベット、半角数字、-、_、. のみ使用できます。' }
+                   format: { with: /\A[a-zA-Z0-9\-_. ]+\z/, message: 'はアルファベット、半角数字、-、_、.、および空白のみ使用できます。' }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,31 @@ class User < ApplicationRecord
   has_many :user_learned_tags
   has_many :learned_tags, through: :user_learned_tags, source: :tag
 
+  mount_base64_uploader :avatar, AvatarUploader, file_name: ->(u) { u.id }
+
   validates :uid, presence: true, uniqueness: true
   validates :provider, presence: true
   validates :github_uid, presence: true, uniqueness: true
+
+  def add_learned_tags(tags)
+    learned_tags.destroy_all
+
+    return if tags.blank?
+
+    tags.each do |tag|
+      tag = Tag.find_or_create_by(name: tag)
+      learned_tags << tag
+    end
+  end
+
+  def add_learning_tags(tags)
+    learning_tags.destroy_all
+
+    return if tags.blank?
+
+    tags.each do |tag|
+      tag = Tag.find_or_create_by(name: tag)
+      learning_tags << tag
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   include UuidSetter
   before_create :set_uuid
@@ -9,7 +11,7 @@ class User < ApplicationRecord
   has_many :user_learned_tags
   has_many :learned_tags, through: :user_learned_tags, source: :tag
 
-  mount_base64_uploader :avatar, AvatarUploader, file_name: ->(u) { u.id }
+  mount_base64_uploader :avatar, AvatarUploader, file_name: lambda(&:id)
 
   validates :uid, presence: true, uniqueness: true
   validates :provider, presence: true
@@ -18,7 +20,7 @@ class User < ApplicationRecord
   def add_learned_tags(tags)
     learned_tags.destroy_all
 
-    return if tags.blank?
+    return if tags[0].blank?
 
     tags.each do |tag|
       tag = Tag.find_or_create_by(name: tag)
@@ -29,7 +31,7 @@ class User < ApplicationRecord
   def add_learning_tags(tags)
     learning_tags.destroy_all
 
-    return if tags.blank?
+    return if tags[0].blank?
 
     tags.each do |tag|
       tag = Tag.find_or_create_by(name: tag)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,14 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :uuid, :name, :github_uid, :profile
+  attributes :uuid, :name, :github_uid, :profile, :avatar
   has_many :questions, serializer: QuestionSerializer
+  has_many :learned_tags, serializer: TagSerializer
+  has_many :learning_tags, serializer: TagSerializer
+
+  def avatar
+    if Rails.env.development?
+      "http://localhost:3000#{object.avatar.url}"
+    else
+      object.avatar.url
+    end
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserSerializer < ActiveModel::Serializer
   attributes :uuid, :name, :github_uid, :profile, :avatar
   has_many :questions, serializer: QuestionSerializer

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AvatarUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
@@ -52,6 +54,6 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   def filename
-    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
+    "#{super.chomp(File.extname(super))}.webp" if original_filename.present?
   end
 end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,57 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.development?
+    storage :file
+  elsif Rails.env.production?
+    storage :fog
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "avatars/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  process resize_to_fit: [500, 500]
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w[jpg jpeg gif png heic webp]
+  end
+
+  process :convert_to_webp
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format('webp')
+      img
+    end
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  def filename
+    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
+  end
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CarrierWave.configure do |config|
   if Rails.env.development?
     config.storage = :file

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,19 @@
+CarrierWave.configure do |config|
+  if Rails.env.development?
+    config.storage = :file
+    config.enable_procession = false if Rails.env.test?
+  elsif Rails.env.production?
+    config.cache_dir = "#{Rails.root}/tmp/uploads"
+    config.storage = :fog
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory = 'project-rqb' if Rails.env.production?
+    config.fog_public = false
+    config.fog_authenticated_url_expiration = 60
+  end
+end
+CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:].\-+]/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
       end
       get 'questions/all_count', to: 'questions#count_all_questions'
       post 'questions/ai_review', to: 'questions#ai_review'
+
+      resources :users, only: %i[show update]
     end
   end
 end

--- a/db/migrate/20240914100650_add_avatar_to_users.rb
+++ b/db/migrate/20240914100650_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_03_013421) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_14_100650) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_03_013421) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "uuid", null: false
+    t.string "avatar"
     t.index ["uid"], name: "index_users_on_uid", unique: true
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end


### PR DESCRIPTION
# 概要
ユーザープロフィールの実装を行いました

## 補足
本環境のみS3を使うようにしているので、マージ後に動作確認します。
画像加工はフロントでwebpにしてからバックへ送信というのも考えたのですが、デプロイサーバーもリージョンも同じなのでそこまで差異はないかな？と考えバックで加工するようにしています。
また、バックへはbase64の画像データを送信しているので`carrierwave-base64`というcarrierwaveのbase64版を導入しています（Gemでやったほうが楽だから）

## 挙動
<img src="https://i.gyazo.com/aabee56501c61e4cc201b57911b4a503.gif" width="400px" />

# 注意事項
webpに変更する画像加工をしているので、Dockerfile.dev Dockerfileを修正しています。
マージ後に最新版で作業するときは`docker compose build`もお願いします！