### PR TITLE
【feature】ユーザーページにユーザーが質問・回答した一覧表示

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,13 +3,12 @@
 module Api
   module V1
     class UsersController < Api::V1::BasesController
+      include Pagy::Backend
+      rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
       def show
-        user = User.find_by(uuid: params[:id])
-        if user.present?
-          render json: user, serializer: UserSerializer, status: :ok
-        else
-          render json: { error: 'ユーザーが見つかりません' }, status: :not_found
-        end
+        user = User.find_by!(uuid: params[:id])
+        render json: user, serializer: UserSerializer, status: :ok
       end
 
       def update
@@ -26,10 +25,38 @@ module Api
         end
       end
 
+      def questions
+        user = User.find_by!(uuid: params[:id])
+        tab = params[:tab] || 'questions'
+        current_page = params[:page] || 1
+        _, questions = fetch_questions(user, tab, current_page)
+        render json: questions, each_serializer: QuestionSerializer, status: :ok
+      end
+
+      def all_questions_count
+        user = User.find_by!(uuid: params[:id])
+        tab = params[:tab] || 'questions'
+        all_count = tab == 'questions' ? user.questions.count : user.answers.count
+        render json: { count: all_count }, status: :ok
+      end
+
       private
 
       def user_params
         params.require(:user).permit(:name, :profile, :avatar, learned_tags: [], learning_tags: [])
+      end
+
+      def record_not_found
+        render json: { error: 'ユーザーが見つかりません' }, status: :not_found
+      end
+
+      def fetch_questions(user, tab, current_page)
+        if tab == 'questions'
+          pagy(user.questions.order('created_at desc'), items: 10, page: current_page)
+        else
+          questions_relation = Question.joins(:answers).where(answers: { user_id: user.id }).order('questions.created_at desc')
+          pagy(questions_relation, items: 10, page: current_page)
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,12 @@ Rails.application.routes.draw do
       get 'questions/all_count', to: 'questions#count_all_questions'
       post 'questions/ai_review', to: 'questions#ai_review'
 
-      resources :users, only: %i[show update]
+      resources :users, only: %i[show update] do
+        member do
+          get 'questions', to: 'users#questions'
+          get 'all_questions_count', to: 'users#all_questions_count'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# 概要
ユーザーページに、そのユーザーが質問・回答した質問一覧表示のためのエンドポイントを作成しました。

## 挙動
| PC（動作確認込） | SP（見た目） |
| --- | --- |
| <img src="https://i.gyazo.com/dc8bb47adc49b9568d95b3a4f74c4599.gif" width="380px" /> | <img src="https://i.gyazo.com/bb3a1797de4d2ae3fa3fa9bbd99e5cbf.png" width="150px" /> |

### その他
`rescue_from ActiveRecord::RecordNotFound, with: :record_not_found`の部分はQuestionでも使っているのでリファクタリングの機会あったらモジュール化してまとめても良いかなと思いました。
