### PR TITLE
ユーザーページにて回答が複数表示されてしまう問題を修正 close #72

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -37,7 +37,7 @@ module Api
       def all_questions_count
         user = User.find_by!(uuid: params[:id])
         tab = params[:tab] || 'questions'
-        all_count = tab == 'questions' ? user.questions.count : user.answers.count
+        all_count = tab == 'questions' ? user.questions.count : user.answers.select(:question_id).distinct.count
         render json: { count: all_count }, status: :ok
       end
 
@@ -55,7 +55,7 @@ module Api
         if tab == 'questions'
           pagy(user.questions.order('created_at desc'), items: 10, page: current_page)
         else
-          questions_relation = Question.joins(:answers).where(answers: { user_id: user.id }).order('questions.created_at desc')
+          questions_relation = Question.joins(:answers).where(answers: { user_id: user.id }).order('questions.created_at desc').distinct
           pagy(questions_relation, items: 10, page: current_page)
         end
       end


### PR DESCRIPTION
## 問題
ユーザーページにて回答タブの内容が回答を行った分だけ表示されてしまう問題を解決

## 確認事項

- [x] 複数回答していても、１つの質問が表示されるようになっているか

## キャプチャ
[![Image from Gyazo](https://i.gyazo.com/92f7a9b7a043b736fd48ae38bd57fd53.gif)](https://gyazo.com/92f7a9b7a043b736fd48ae38bd57fd53)